### PR TITLE
Added Routes for questionpools, tests and courses

### DIFF
--- a/RESTController/extensions/courses_v1/routes/CourseRoutes.php
+++ b/RESTController/extensions/courses_v1/routes/CourseRoutes.php
@@ -251,7 +251,11 @@ $app->group('/v1', function () use ($app) {
     });
 
     /**
-     * Retrieves the content of a course.
+     * Retrieves all contents of a course.
+     * (OPTIONAL) Results can be filtered by adding these parameters to the request:
+     *      "types": comma seperated list of all desired types of objects, e.g. "fold, tst"
+     *      "title": title of the objects
+     *      "description": description of the objects
      */
     $app->get('/courses/searchCourse/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
         $app->log->debug('in course get ref_id= '.$ref_id);
@@ -286,7 +290,7 @@ $app->group('/v1', function () use ($app) {
 
             //filter for type
             $type_filter = array();
-            if($types != '*'){
+            if($types != '*' && $types != ''){
                 $types = explode(',', $types);
                 foreach($contents as $content){
                     if(in_array($content['type'], $types)){
@@ -300,7 +304,7 @@ $app->group('/v1', function () use ($app) {
 
             //filter for title
             $title_filter = array();
-            if($title != '*'){
+            if($title != '*' && $title != ''){
                 $title = mb_strtolower($title, 'UTF-8');
                 foreach($type_filter as $content){
                     $content_title = mb_strtolower($content['title'], 'UTF-8');
@@ -315,7 +319,7 @@ $app->group('/v1', function () use ($app) {
 
             //filter for description
             $description_filter = array();
-            if($description != '*'){
+            if($description != '*' && $description != ''){
                 $description = mb_strtolower($description, 'UTF-8');
                 foreach($title_filter as $content){
                     $content_description = mb_strtolower($content['description'], 'UTF-8');

--- a/RESTController/extensions/courses_v1/routes/CourseRoutes.php
+++ b/RESTController/extensions/courses_v1/routes/CourseRoutes.php
@@ -278,25 +278,53 @@ $app->group('/v1', function () use ($app) {
                 }
             }
 
-            $types = $app->request->getParameter('types','all');
-            $title = $app->request->getParameter('title','all');
-            $description = $app->request->getParameter('description','all');
+            //get filter parameters
+            $types = $app->request->getParameter('types','*');
+            $title = $app->request->getParameter('title','*');
+            $description = $app->request->getParameter('description','*');
             $filtered_contents = array();
 
             //filter for type
-            if($types != 'all'){
+            $type_filter = array();
+            if($types != '*'){
                 $types = explode(',', $types);
                 foreach($contents as $content){
                     if(in_array($content['type'], $types)){
-                        array_push($filtered_contents, $content);
+                        array_push($type_filter, $content);
                     }
                 }
             }
             else{
-                foreach($contents as $content){
-                    array_push($filtered_contents, $content);
+                $type_filter = $contents;
+            }
+
+            //filter for title
+            $title_filter = array();
+            if($title != '*'){
+                foreach($type_filter as $content){
+                    if(strpos($content['title'], $title) !== false){
+                        array_push($title_filter, $content);
+                    }
                 }
             }
+            else{
+                $title_filter = $type_filter;
+            }
+
+            //filter for description
+            $description_filter = array();
+            if($description != '*'){
+                foreach($title_filter as $content){
+                    if(strpos($content['description'], $description) !== false){
+                        array_push($description_filter, $content);
+                    }
+                }
+            }
+            else{
+                $description_filter = $title_filter;
+            }
+
+            $filtered_contents = $description_filter;
 
             $result = array(
                 'contents' => $filtered_contents, // course contents

--- a/RESTController/extensions/courses_v1/routes/CourseRoutes.php
+++ b/RESTController/extensions/courses_v1/routes/CourseRoutes.php
@@ -301,8 +301,10 @@ $app->group('/v1', function () use ($app) {
             //filter for title
             $title_filter = array();
             if($title != '*'){
+                $title = mb_strtolower($title, 'UTF-8');
                 foreach($type_filter as $content){
-                    if(strpos($content['title'], $title) !== false){
+                    $content_title = mb_strtolower($content['title'], 'UTF-8');
+                    if(strpos($content_title, $title) !== false){
                         array_push($title_filter, $content);
                     }
                 }
@@ -314,8 +316,10 @@ $app->group('/v1', function () use ($app) {
             //filter for description
             $description_filter = array();
             if($description != '*'){
+                $description = mb_strtolower($description, 'UTF-8');
                 foreach($title_filter as $content){
-                    if(strpos($content['description'], $description) !== false){
+                    $content_description = mb_strtolower($content['description'], 'UTF-8');
+                    if(strpos($content_description, $description) !== false){
                         array_push($description_filter, $content);
                     }
                 }

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -46,7 +46,9 @@ class QuestionpoolModel extends Libs\RESTModel {
             }
          }
          else {
-            $result = $questions;
+            foreach($questions as $question){
+                array_push($result, $question);
+            }
          }
 
         return $result;

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -13,6 +13,8 @@ use \RESTController\libs as Libs;
 require_once('./Services/Utilities/classes/class.ilUtil.php');
 require_once('./Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php');
 require_once('./Modules/TestQuestionPool/classes/class.assTextQuestion.php');
+require_once('./Modules/TestQuestionPool/classes/class.assSingleChoice.php');
+
 
 class QuestionpoolModel extends Libs\RESTModel {
 
@@ -56,4 +58,29 @@ class QuestionpoolModel extends Libs\RESTModel {
         }
         return $answers;
     }  
+
+    /**
+     * Returns the answer for a question of type 1 = assSingleChoice
+     * @param $ref_id
+     * @param $user_id
+     * @return array
+    */
+    public function getSingleChoiceAnswers($ref_id, $user_id)
+    {
+        Libs\RESTilias::loadIlUser($user_id);
+        Libs\RESTilias::initAccessHandling();
+
+        $sc_question = new \assSingleChoice();
+        $sc_question->loadFromDb($ref_id);
+
+        $answers = array();
+        foreach($sc_question->answers as $answer){
+           $result = array(
+                'answertext' => $answer->getAnswertext(),
+                'points' => $answer->getPoints()
+            ); 
+           array_push($answers, $result);
+        }
+        return $answers;
+    }
 }

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * ILIAS REST Plugin for the ILIAS LMS
+ *
+ * Authors: D.Schaefer and T.Hufschmidt <(schaefer|hufschmidt)@hrz.uni-marburg.de>
+ * Since 2014
+ */
+namespace RESTController\extensions\questionpools_v1;
+
+// This allows us to use shortcuts instead of full quantifier
+use \RESTController\libs as Libs;
+
+require_once('./Services/Utilities/classes/class.ilUtil.php');
+require_once('./Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php');
+
+class QuestionpoolModel extends Libs\RESTModel {
+
+    /**
+     * Returns all questions of a test
+     * @param $ref_id
+     * @param $user_id
+     * @return array
+    */
+    public function getQuestions($ref_id, $user_id)
+    {
+        Libs\RESTilias::loadIlUser($user_id);
+        Libs\RESTilias::initAccessHandling();
+        $test = new \ilObjQuestionPool($ref_id);
+        $test->read();
+        $questions = $test->getPrintviewQuestions();
+        return $questions;
+    }
+    
+}

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -35,18 +35,20 @@ class QuestionpoolModel extends Libs\RESTModel {
         $questions = $questionpool->getPrintviewQuestions();
 
         $result = array();
+
         //filter questions that match the provided types parameter
         if($types != 'all'){
+            $types = explode(',', $types);
             foreach($questions as $question){
-                $question_type = $question['question_type_fi'];
-                if(strpos($types, $question_type) !== false){
+                if(in_array($question['question_type_fi'], $types)){
                     array_push($result, $question);
                 }
             }
-        }
-        else{
+         }
+         else {
             $result = $questions;
-        }
+         }
+
         return $result;
     }
 

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -14,6 +14,7 @@ require_once('./Services/Utilities/classes/class.ilUtil.php');
 require_once('./Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php');
 require_once('./Modules/TestQuestionPool/classes/class.assTextQuestion.php');
 require_once('./Modules/TestQuestionPool/classes/class.assSingleChoice.php');
+require_once('./Modules/TestQuestionPool/classes/class.assMultipleChoice.php');
 
 
 class QuestionpoolModel extends Libs\RESTModel {
@@ -71,6 +72,31 @@ class QuestionpoolModel extends Libs\RESTModel {
         Libs\RESTilias::initAccessHandling();
 
         $sc_question = new \assSingleChoice();
+        $sc_question->loadFromDb($ref_id);
+
+        $answers = array();
+        foreach($sc_question->answers as $answer){
+           $result = array(
+                'answertext' => $answer->getAnswertext(),
+                'points' => $answer->getPoints()
+            ); 
+           array_push($answers, $result);
+        }
+        return $answers;
+    }
+
+    /**
+     * Returns the answer for a question of type 2 = assMultipleChoice
+     * @param $ref_id
+     * @param $user_id
+     * @return array
+    */
+    public function getMultipleChoiceAnswers($ref_id, $user_id)
+    {
+        Libs\RESTilias::loadIlUser($user_id);
+        Libs\RESTilias::initAccessHandling();
+
+        $sc_question = new \assMultipleChoice();
         $sc_question->loadFromDb($ref_id);
 
         $answers = array();

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -12,11 +12,12 @@ use \RESTController\libs as Libs;
 
 require_once('./Services/Utilities/classes/class.ilUtil.php');
 require_once('./Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php');
+require_once('./Modules/TestQuestionPool/classes/class.assTextQuestion.php');
 
 class QuestionpoolModel extends Libs\RESTModel {
 
     /**
-     * Returns all questions of a test
+     * Returns all questions of a questionpool
      * @param $ref_id
      * @param $user_id
      * @return array
@@ -25,10 +26,34 @@ class QuestionpoolModel extends Libs\RESTModel {
     {
         Libs\RESTilias::loadIlUser($user_id);
         Libs\RESTilias::initAccessHandling();
-        $test = new \ilObjQuestionPool($ref_id);
-        $test->read();
-        $questions = $test->getPrintviewQuestions();
+        $questionpool = new \ilObjQuestionPool($ref_id);
+        $questionpool->read();
+        $questions = $questionpool->getPrintviewQuestions();
         return $questions;
     }
-    
+
+    /**
+     * Returns the answers for a question of type 8 = assTextQuestion
+     * @param $ref_id
+     * @param $user_id
+     * @return array
+    */
+    public function getTextAnswers($ref_id, $user_id)
+    {
+        Libs\RESTilias::loadIlUser($user_id);
+        Libs\RESTilias::initAccessHandling();
+
+        $text_question = new \assTextQuestion();
+        $text_question->loadFromDb($ref_id);
+        
+        $answers = array();
+        foreach($text_question->answers as $answer){
+           $result = array(
+                'answertext' => $answer->getAnswertext(),
+                'points' => $answer->getPoints()
+            ); 
+           array_push($answers, $result);
+        }
+        return $answers;
+    }  
 }

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -46,9 +46,7 @@ class QuestionpoolModel extends Libs\RESTModel {
             }
          }
          else {
-            foreach($questions as $question){
-                array_push($result, $question);
-            }
+            $result = $questions;
          }
 
         return $result;

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -37,7 +37,7 @@ class QuestionpoolModel extends Libs\RESTModel {
         $result = array();
 
         //filter questions that match the provided types parameter
-        if($types != '*'){
+        if($types != '*' && $types != ''){
             $types = explode(',', $types);
             foreach($questions as $question){
                 if(in_array($question['question_type_fi'], $types)){

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -20,19 +20,34 @@ require_once('./Modules/TestQuestionPool/classes/class.assMultipleChoice.php');
 class QuestionpoolModel extends Libs\RESTModel {
 
     /**
-     * Returns all questions of a questionpool
+     * Returns questions of a questionpool
      * @param $ref_id
      * @param $user_id
+     * @param $types
      * @return array
     */
-    public function getQuestions($ref_id, $user_id)
+    public function getQuestions($ref_id, $user_id, $types)
     {
         Libs\RESTilias::loadIlUser($user_id);
         Libs\RESTilias::initAccessHandling();
         $questionpool = new \ilObjQuestionPool($ref_id);
         $questionpool->read();
         $questions = $questionpool->getPrintviewQuestions();
-        return $questions;
+
+        $result = array();
+        //filter questions that match the provided types parameter
+        if($types != 'all'){
+            foreach($questions as $question){
+                $question_type = $question['question_type_fi'];
+                if(strpos($types, $question_type) !== false){
+                    array_push($result, $question);
+                }
+            }
+        }
+        else{
+            $result = $questions;
+        }
+        return $result;
     }
 
     /**

--- a/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
+++ b/RESTController/extensions/questionpools_v1/models/QuestionpoolModel.php
@@ -37,7 +37,7 @@ class QuestionpoolModel extends Libs\RESTModel {
         $result = array();
 
         //filter questions that match the provided types parameter
-        if($types != 'all'){
+        if($types != '*'){
             $types = explode(',', $types);
             foreach($questions as $question){
                 if(in_array($question['question_type_fi'], $types)){

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -17,7 +17,7 @@ $app->group('/v1', function () use ($app) {
     /**
      * Gets the questions of a Questionpool
      * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
-     * e.g. "1, 2, 8" for single choice, multiple choice and text questions only.
+     * e.g. "1,2,8" for single choice, multiple choice and text questions only.
      */
     $app->get('/questionpools/getQuestions/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
         try {

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * ILIAS REST Plugin for the ILIAS LMS
+ *
+ * Authors: D.Schaefer, T.Hufschmidt <(schaefer|hufschmidt)@hrz.uni-marburg.de>
+ * Since 2014
+ */
+namespace RESTController\extensions\questionpools_v1;
+
+// This allows us to use shortcuts instead of full quantifier
+use \RESTController\libs\RESTAuth as RESTAuth;
+use \RESTController\libs as Libs;
+use \RESTController\core\auth as Auth;
+use \RESTController\extensions\questionpools_v1 as Questionpools;
+
+$app->group('/v1', function () use ($app) {
+    /**
+     * Gets all questions of a Questionpool
+     */
+    $app->get('/questionpools/getQuestions/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
+        try {
+            $accessToken = $app->request->getToken();
+            $user_id = $accessToken->getUserId();
+
+            $test_model = new QuestionpoolModel();
+            $questions = $test_model->getQuestions($ref_id, $user_id);
+
+            $result = array(
+                'questions' => $questions
+            );
+
+            $app->success($result);
+        } catch (Libs\Exceptions\ReadFailed $e) {
+            $app->halt(500, $e->getFormatedMessage());
+        }
+    });
+
+});

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -22,11 +22,31 @@ $app->group('/v1', function () use ($app) {
             $accessToken = $app->request->getToken();
             $user_id = $accessToken->getUserId();
 
-            $test_model = new QuestionpoolModel();
-            $questions = $test_model->getQuestions($ref_id, $user_id);
+            $questionpool_model = new QuestionpoolModel();
+            $questions = $questionpool_model->getQuestions($ref_id, $user_id);
 
             $result = array(
                 'questions' => $questions
+            );
+
+            $app->success($result);
+        } catch (Libs\Exceptions\ReadFailed $e) {
+            $app->halt(500, $e->getFormatedMessage());
+        }
+    });
+    /**
+     * Gets the answers for a question of type 8 = assTextQuestion
+     */
+    $app->get('/questionpools/getTextAnswers/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
+        try {
+            $accessToken = $app->request->getToken();
+            $user_id = $accessToken->getUserId();
+
+            $questionpool_model = new QuestionpoolModel();
+            $answers = $questionpool_model->getTextAnswers($ref_id, $user_id);
+
+            $result = array(
+                'answers' => $answers
             );
 
             $app->success($result);

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -54,5 +54,26 @@ $app->group('/v1', function () use ($app) {
             $app->halt(500, $e->getFormatedMessage());
         }
     });
+    /**
+     * Gets the answers for a question of type 1 = assSingleChoice
+     */
+    $app->get('/questionpools/getSingleChoiceAnswers/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
+        try {
+            $accessToken = $app->request->getToken();
+            $user_id = $accessToken->getUserId();
+
+            $questionpool_model = new QuestionpoolModel();
+            $answers = $questionpool_model->getSingleChoiceAnswers($ref_id, $user_id);
+
+            $result = array(
+                'answers' => $answers
+            );
+
+            $app->success($result);
+        } catch (Libs\Exceptions\ReadFailed $e) {
+            $app->halt(500, $e->getFormatedMessage());
+        }
+    });
+
 
 });

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -39,6 +39,48 @@ $app->group('/v1', function () use ($app) {
         }
     });
     /**
+     * Gets the questions of a Questionpool including answers for questions of type 1,2,8. Other types still need to be implemented.
+     * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
+     * e.g. "1,2,8" for single choice, multiple choice and text questions only.
+     */
+    $app->get('/questionpools/getQuestionsWithAnswers/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
+        try {
+            $accessToken = $app->request->getToken();
+            $user_id = $accessToken->getUserId();
+
+            $types = $app->request->getParameter('types','*');
+
+            $questionpool_model = new QuestionpoolModel();
+            $questions = $questionpool_model->getQuestions($ref_id, $user_id, $types);
+
+            //get answers for each question
+            foreach($questions as &$question){
+                switch($question['question_type_fi']){
+                    case 1:
+                        //single choice question
+                        $question['answers'] = $questionpool_model->getSingleChoiceAnswers($question['question_id'], $user_id);
+                        break;
+                    case 2:
+                        //multiple choice question
+                        $question['answers'] = $questionpool_model->getMultipleChoiceAnswers($question['question_id'], $user_id);
+                        break;
+                    case 8:
+                        //text question
+                        $question['answers'] = $questionpool_model->getTextAnswers($question['question_id'], $user_id);
+                        break;
+                }
+            }
+
+            $result = array(
+                'questions' => $questions
+            );
+        
+            $app->success($result);
+        } catch (Libs\Exceptions\ReadFailed $e) {
+            $app->halt(500, $e->getFormatedMessage());
+        }
+    });
+    /**
      * Gets the answers for a question of type 8 = assTextQuestion
      */
     $app->get('/questionpools/getTextAnswers/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -74,6 +74,25 @@ $app->group('/v1', function () use ($app) {
             $app->halt(500, $e->getFormatedMessage());
         }
     });
+    /**
+     * Gets the answers for a question of type 2 = assMultipleChoice
+     */
+    $app->get('/questionpools/getMultipleChoiceAnswers/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
+        try {
+            $accessToken = $app->request->getToken();
+            $user_id = $accessToken->getUserId();
 
+            $questionpool_model = new QuestionpoolModel();
+            $answers = $questionpool_model->getMultipleChoiceAnswers($ref_id, $user_id);
+
+            $result = array(
+                'answers' => $answers
+            );
+
+            $app->success($result);
+        } catch (Libs\Exceptions\ReadFailed $e) {
+            $app->halt(500, $e->getFormatedMessage());
+        }
+    });
 
 });

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -24,7 +24,7 @@ $app->group('/v1', function () use ($app) {
             $accessToken = $app->request->getToken();
             $user_id = $accessToken->getUserId();
 
-            $types = $app->request->getParameter('types','all');
+            $types = $app->request->getParameter('types','*');
 
             $questionpool_model = new QuestionpoolModel();
             $questions = $questionpool_model->getQuestions($ref_id, $user_id, $types);

--- a/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
+++ b/RESTController/extensions/questionpools_v1/routes/QuestionpoolRoutes.php
@@ -15,20 +15,24 @@ use \RESTController\extensions\questionpools_v1 as Questionpools;
 
 $app->group('/v1', function () use ($app) {
     /**
-     * Gets all questions of a Questionpool
+     * Gets the questions of a Questionpool
+     * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
+     * e.g. "1, 2, 8" for single choice, multiple choice and text questions only.
      */
     $app->get('/questionpools/getQuestions/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
         try {
             $accessToken = $app->request->getToken();
             $user_id = $accessToken->getUserId();
 
+            $types = $app->request->getParameter('types','all');
+
             $questionpool_model = new QuestionpoolModel();
-            $questions = $questionpool_model->getQuestions($ref_id, $user_id);
+            $questions = $questionpool_model->getQuestions($ref_id, $user_id, $types);
 
             $result = array(
                 'questions' => $questions
             );
-
+        
             $app->success($result);
         } catch (Libs\Exceptions\ReadFailed $e) {
             $app->halt(500, $e->getFormatedMessage());

--- a/RESTController/extensions/tests_v1/models/TestModel.php
+++ b/RESTController/extensions/tests_v1/models/TestModel.php
@@ -61,4 +61,25 @@ class TestModel extends Libs\RESTModel {
         $test->read();
         return array("title"=>$test->getTitle(),"description"=>$test->getDescription(),"type"=>$type = $test->getType());
     }
+
+    /**
+     * Returns all questions of a test.
+     * @param $ref_id
+     * @param $user_id
+     * @return array
+     */
+    public function getQuestions($ref_id, $user_id)
+    {
+        Libs\RESTilias::loadIlUser($user_id);
+        Libs\RESTilias::initAccessHandling();
+        $test = new \ilObjTest($ref_id);
+        $questions = $test->getAllQuestions();
+
+        $result = array();
+        foreach($questions as $question){
+            array_push($result, $question);
+        }
+
+        return $result;
+    }
 }

--- a/RESTController/extensions/tests_v1/models/TestModel.php
+++ b/RESTController/extensions/tests_v1/models/TestModel.php
@@ -77,18 +77,20 @@ class TestModel extends Libs\RESTModel {
         $questions = $test->getAllQuestions();
 
         $result = array();
+
         //filter questions that match the provided types parameter
         if($types != 'all'){
+            $types = explode(',', $types);
             foreach($questions as $question){
-                $question_type = $question['question_type_fi'];
-                if(strpos($types, $question_type) !== false){
+                if(in_array($question['question_type_fi'], $types)){
                     array_push($result, $question);
                 }
             }
-        }
-        else{
+         }
+         else {
             $result = $questions;
-        }
+         }
+
         return $result;
     }
 }

--- a/RESTController/extensions/tests_v1/models/TestModel.php
+++ b/RESTController/extensions/tests_v1/models/TestModel.php
@@ -88,9 +88,7 @@ class TestModel extends Libs\RESTModel {
             }
          }
          else {
-            foreach($questions as $question){
-                array_push($result, $question);
-            }
+            $result = $questions;
          }
 
         return $result;

--- a/RESTController/extensions/tests_v1/models/TestModel.php
+++ b/RESTController/extensions/tests_v1/models/TestModel.php
@@ -79,7 +79,7 @@ class TestModel extends Libs\RESTModel {
         $result = array();
 
         //filter questions that match the provided types parameter
-        if($types != 'all'){
+        if($types != '*' && $types != ''){
             $types = explode(',', $types);
             foreach($questions as $question){
                 if(in_array($question['question_type_fi'], $types)){

--- a/RESTController/extensions/tests_v1/models/TestModel.php
+++ b/RESTController/extensions/tests_v1/models/TestModel.php
@@ -88,7 +88,9 @@ class TestModel extends Libs\RESTModel {
             }
          }
          else {
-            $result = $questions;
+            foreach($questions as $question){
+                array_push($result, $question);
+            }
          }
 
         return $result;

--- a/RESTController/extensions/tests_v1/models/TestModel.php
+++ b/RESTController/extensions/tests_v1/models/TestModel.php
@@ -66,9 +66,10 @@ class TestModel extends Libs\RESTModel {
      * Returns all questions of a test.
      * @param $ref_id
      * @param $user_id
+     * @param $types
      * @return array
      */
-    public function getQuestions($ref_id, $user_id)
+    public function getQuestions($ref_id, $user_id, $types)
     {
         Libs\RESTilias::loadIlUser($user_id);
         Libs\RESTilias::initAccessHandling();
@@ -76,10 +77,18 @@ class TestModel extends Libs\RESTModel {
         $questions = $test->getAllQuestions();
 
         $result = array();
-        foreach($questions as $question){
-            array_push($result, $question);
+        //filter questions that match the provided types parameter
+        if($types != 'all'){
+            foreach($questions as $question){
+                $question_type = $question['question_type_fi'];
+                if(strpos($types, $question_type) !== false){
+                    array_push($result, $question);
+                }
+            }
         }
-
+        else{
+            $result = $questions;
+        }
         return $result;
     }
 }

--- a/RESTController/extensions/tests_v1/routes/TestRoutes.php
+++ b/RESTController/extensions/tests_v1/routes/TestRoutes.php
@@ -54,14 +54,18 @@ $app->group('/v1', function () use ($app) {
 
     /**
      * Retrieves all questions of a test.
+     * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
+     * e.g. "1, 2, 8" for single choice, multiple choice and text questions only.
      */
     $app->get('/tests/getQuestions/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
         try {
             $accessToken = $app->request->getToken();
             $user_id = $accessToken->getUserId();
 
+            $types = $app->request->getParameter('types','all');
+
             $test_model = new TestModel();
-            $questions = $test_model->getQuestions($ref_id,$user_id);
+            $questions = $test_model->getQuestions($ref_id,$user_id, $types);
 
             $result = array(
                 'questions' => $questions

--- a/RESTController/extensions/tests_v1/routes/TestRoutes.php
+++ b/RESTController/extensions/tests_v1/routes/TestRoutes.php
@@ -52,4 +52,25 @@ $app->group('/v1', function () use ($app) {
         }
     });
 
+    /**
+     * Retrieves all questions of a test.
+     */
+    $app->get('/tests/getQuestions/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
+        try {
+            $accessToken = $app->request->getToken();
+            $user_id = $accessToken->getUserId();
+
+            $test_model = new TestModel();
+            $questions = $test_model->getQuestions($ref_id,$user_id);
+
+            $result = array(
+                'test' => $questions
+            );
+
+            $app->success($result);
+        } catch (Libs\Exceptions\ReadFailed $e) {
+            $app->halt(500, $e->getFormatedMessage());
+        }
+    });
+
 });

--- a/RESTController/extensions/tests_v1/routes/TestRoutes.php
+++ b/RESTController/extensions/tests_v1/routes/TestRoutes.php
@@ -62,7 +62,7 @@ $app->group('/v1', function () use ($app) {
             $accessToken = $app->request->getToken();
             $user_id = $accessToken->getUserId();
 
-            $types = $app->request->getParameter('types','all');
+            $types = $app->request->getParameter('types','*');
 
             $test_model = new TestModel();
             $questions = $test_model->getQuestions($ref_id,$user_id, $types);

--- a/RESTController/extensions/tests_v1/routes/TestRoutes.php
+++ b/RESTController/extensions/tests_v1/routes/TestRoutes.php
@@ -12,6 +12,7 @@ use \RESTController\libs\RESTAuth as RESTAuth;
 use \RESTController\libs as Libs;
 use \RESTController\core\auth as Auth;
 use \RESTController\extensions\tests_v1 as Tests;
+use \RESTController\extensions\questionpools_v1 as Questionpools;
 
 $app->group('/v1', function () use ($app) {
     /**
@@ -77,4 +78,47 @@ $app->group('/v1', function () use ($app) {
         }
     });
 
+    /**
+     * Retrieves all questions of a test including answers for questions of type 1,2,8. Other types still need to be implemented.
+     * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
+     * e.g. "1,2,8" for single choice, multiple choice and text questions only.
+     */
+    $app->get('/tests/getQuestionsWithAnswers/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
+        try {
+            $accessToken = $app->request->getToken();
+            $user_id = $accessToken->getUserId();
+
+            $types = $app->request->getParameter('types','*');
+
+            $test_model = new TestModel();
+            $questions = $test_model->getQuestions($ref_id,$user_id, $types);
+
+            //get answers for each question
+            $questionpool_model = new Questionpools\QuestionpoolModel();
+            foreach($questions as &$question){
+                switch($question['question_type_fi']){
+                    case 1:
+                        //single choice question
+                        $question['answers'] = $questionpool_model->getSingleChoiceAnswers($question['question_id'], $user_id);
+                        break;
+                    case 2:
+                        //multiple choice question
+                        $question['answers'] = $questionpool_model->getMultipleChoiceAnswers($question['question_id'], $user_id);
+                        break;
+                    case 8:
+                        //text question
+                        $question['answers'] = $questionpool_model->getTextAnswers($question['question_id'], $user_id);
+                        break;
+                }
+            }
+
+            $result = array(
+                'questions' => $questions
+            );
+
+            $app->success($result);
+        } catch (Libs\Exceptions\ReadFailed $e) {
+            $app->halt(500, $e->getFormatedMessage());
+        }
+    });
 });

--- a/RESTController/extensions/tests_v1/routes/TestRoutes.php
+++ b/RESTController/extensions/tests_v1/routes/TestRoutes.php
@@ -55,7 +55,7 @@ $app->group('/v1', function () use ($app) {
     /**
      * Retrieves all questions of a test.
      * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
-     * e.g. "1, 2, 8" for single choice, multiple choice and text questions only.
+     * e.g. "1,2,8" for single choice, multiple choice and text questions only.
      */
     $app->get('/tests/getQuestions/:ref_id', RESTAuth::checkAccess(RESTAuth::PERMISSION), function ($ref_id) use ($app) {
         try {

--- a/RESTController/extensions/tests_v1/routes/TestRoutes.php
+++ b/RESTController/extensions/tests_v1/routes/TestRoutes.php
@@ -64,7 +64,7 @@ $app->group('/v1', function () use ($app) {
             $questions = $test_model->getQuestions($ref_id,$user_id);
 
             $result = array(
-                'test' => $questions
+                'questions' => $questions
             );
 
             $app->success($result);


### PR DESCRIPTION
Route for courses: 
- /courses/searchCourse/:ref_id
     /**
     * Retrieves all contents of a course.
     * (OPTIONAL) Results can be filtered by adding these parameters to the request:
     * "types": comma seperated list of all desired types of objects, e.g. "fold, tst"
     * "title": title of the objects
     * "description": description of the objects
     */

Routes for questionpools:
- /questionpools/getQuestions/:ref_id
      /**
     * Gets the questions of a Questionpool
     * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
     * e.g. "1,2,8" for single choice, multiple choice and text questions only.
     */

- /questionpools/getTextAnswers/:ref_id
     /**
     * Gets the answers for a question of type 8 = assTextQuestion
     */

- /questionpools/getSingleChoiceAnswers/:ref_id
     /**
     * Gets the answers for a question of type 1 = assSingleChoice
     */

- /questionpools/getMultipleChoiceAnswers/:ref_id
     /**
     * Gets the answers for a question of type 2 = assMultipleChoice
     */

Route for tests:
- /tests/getQuestions/:ref_id
     /**
     * Retrieves all questions of a test.
     * (OPTIONAL) Desired types of questions can be specified in the 'types' parameter of the request 
     * e.g. "1,2,8" for single choice, multiple choice and text questions only.
     */